### PR TITLE
Character types and subtypes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -48,6 +48,11 @@
   flex-direction: row;
 }
 
+.flex-space-between {
+  display: flex;
+  justify-content: space-between;
+}
+
 /* Came default */
 
 .App-logo {

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -34,6 +34,7 @@ const ApplicationViews = props => {
         render={props => {
           return <TypeDetail 
             subTypeId={props.match.params.subTypeId}
+            verbose={true}
             {...props}
           />
       }}/>

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -8,6 +8,8 @@ import CharacterList from "./character/CharacterList";
 import CharacterSheet from "./character/sheet/CharacterSheet";
 import CharacterForm from "./character/form/CharacterForm";
 import MainForm from "./character/form/MainForm";
+import TypeList from "./character/types/TypeList";
+import TypeDetail from "./character/types/TypeDetail";
 
 import Login from "./user/Login"
 import Register from "./user/Register"
@@ -24,6 +26,16 @@ const ApplicationViews = props => {
       }}/>
       <Route path="/stunts" render={props => {
         return <StuntList {...props}/>
+      }}/>
+      <Route exact path="/types" render={props => {
+        return <TypeList {...props}/>
+      }}/>
+      <Route path="/types/:subTypeId(\d+)" 
+        render={props => {
+          return <TypeDetail 
+            subTypeId={props.match.params.subTypeId}
+            {...props}
+          />
       }}/>
       {/* -------------------CHARACTER------------------- */}
       {/* TODO: Make root be something other than characters */}

--- a/src/components/character/CharacterCard.js
+++ b/src/components/character/CharacterCard.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { Card, Button, Icon } from "semantic-ui-react"
+import { Card, Button, Icon, Label } from "semantic-ui-react"
 import "./Character.css";
 
 const CharacterCard = props => {
@@ -17,39 +17,49 @@ const CharacterCard = props => {
         description={props.highConcept}
         meta={`by: ${user.email}`}
         extra={
-          /* Conditionally rendering these buttons 
-          if the user created this character */
-          activeUser && activeUser.id === user.id
-          ? <div className="flex-end">
-            <Link to={`/characters/${character.id}`}>
-              <Button 
-                className="ui button"
-              >
-                <Icon fitted className="file outline"/>
-              </Button>
-            </Link>  
-            <Button className="ui button"
-                onClick={props.handleDelete}
-              >
-              <Icon fitted className="trash alternate outline"/>
-            </Button>
-            <Link to={`/characters/${character.id}/edit`}>
-              <Button 
-                className="ui button"
-              >
-                <Icon fitted className="edit outline"/>
-              </Button>
-            </Link>
-          </div>
-          : <div className="flex-end">
-            <Link to={`/characters/${character.id}`}>
-              <Button 
-                className="ui button"
-              >
-                <Icon fitted className="file outline"/>
-              </Button>
-            </Link>  
-          </div>
+          <>
+            {/* A label detailing what character subtype they are  */}
+            <Label
+              tag
+              color="blue"
+              size="tiny"
+              content={props.character.characterSubType.name}
+            />
+            {/* Conditionally rendering these buttons 
+            if the user created this character */}
+            {activeUser && activeUser.id === user.id
+            ? <div className="flex-end">
+                <Link to={`/characters/${character.id}`}>
+                  <Button 
+                    className="ui button"
+                  >
+                    <Icon fitted className="file outline"/>
+                  </Button>
+                </Link>  
+                <Button className="ui button"
+                    onClick={props.handleDelete}
+                  >
+                  <Icon fitted className="trash alternate outline"/>
+                </Button>
+                <Link to={`/characters/${character.id}/edit`}>
+                  <Button 
+                    className="ui button"
+                  >
+                    <Icon fitted className="edit outline"/>
+                  </Button>
+                </Link>
+              </div>
+            : <div className="flex-end">
+              <Link to={`/characters/${character.id}`}>
+                <Button 
+                  className="ui button"
+                >
+                  <Icon fitted className="file outline"/>
+                </Button>
+              </Link>  
+            </div>
+            }
+          </>
         }
       />
 

--- a/src/components/character/form/AspectsForm.js
+++ b/src/components/character/form/AspectsForm.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { Divider } from "semantic-ui-react";
+import { Divider, Grid } from "semantic-ui-react";
 import AspectInput from "./AspectInput"
 import ApiManager from "../../../modules/ApiManager"
 
 const AspectForm = props => {
+  const type = props.type;
   const aspects = props.aspects;
   const maxAspects = props.maxAspects;
   const aspectComment = props.aspectComment;
@@ -35,6 +36,32 @@ const AspectForm = props => {
       .then(setAspectTypes)
   }
 
+  const createAspectInputs = () => {
+    let aspectInputs = [];
+    for (let i = 0; i < maxAspects; i++) {
+      let typeId;
+      // TODO: make aspect type an option
+      // and less hard-coded
+      if (i === 0) {
+        typeId = 1;
+      } else if (i === 1) {
+        typeId = 2;
+      } else if (i > 1) {
+        typeId = 3;
+      }
+      aspectInputs.push(
+        <AspectInput 
+          handleFieldChange={handleFieldChange} 
+          aspects={aspects} 
+          index={i} 
+          typeId={typeId} 
+          aspectTypes={aspectTypes}
+          />
+      )
+    }
+    return aspectInputs;
+  }
+
   useEffect(() => {
     getAspectTypes();
   },[])
@@ -43,11 +70,16 @@ const AspectForm = props => {
   return (
     <>
       <Divider horizontal><h2>ASPECTS</h2></Divider>
-      <AspectInput handleFieldChange={handleFieldChange} aspects={aspects} index="0" typeId="1" aspectTypes={aspectTypes}/>
-      <AspectInput handleFieldChange={handleFieldChange} aspects={aspects} index="1" typeId="2" aspectTypes={aspectTypes}/>
-      <AspectInput handleFieldChange={handleFieldChange} aspects={aspects} index="2" typeId="3" aspectTypes={aspectTypes}/>
-      <AspectInput handleFieldChange={handleFieldChange} aspects={aspects} index="3" typeId="3" aspectTypes={aspectTypes}/>
-      <AspectInput handleFieldChange={handleFieldChange} aspects={aspects} index="4" typeId="3" aspectTypes={aspectTypes}/>
+      <Grid columns={2}>
+        <Grid.Column>
+          {createAspectInputs()}
+        </Grid.Column>
+        <Grid.Column>
+          {/* TODO: make this look cleaner on render */}
+          <h3>Aspects for {type}</h3>
+          <p>{aspectComment}</p>
+        </Grid.Column>
+      </Grid>
     </>
   )
 }

--- a/src/components/character/form/AspectsForm.js
+++ b/src/components/character/form/AspectsForm.js
@@ -66,15 +66,14 @@ const AspectForm = props => {
     getAspectTypes();
   },[])
 
-  // TODO: fix up the value to be less hackey
   return (
     <>
       <Divider horizontal><h2>ASPECTS</h2></Divider>
       <Grid columns={2}>
-        <Grid.Column>
+        <Grid.Column width={10}>
           {createAspectInputs()}
         </Grid.Column>
-        <Grid.Column>
+        <Grid.Column width={6}>
           {/* TODO: make this look cleaner on render */}
           <h3>Aspects for {type}</h3>
           <p>{aspectComment}</p>

--- a/src/components/character/form/AspectsForm.js
+++ b/src/components/character/form/AspectsForm.js
@@ -4,7 +4,9 @@ import AspectInput from "./AspectInput"
 import ApiManager from "../../../modules/ApiManager"
 
 const AspectForm = props => {
-  const aspects = props.aspects
+  const aspects = props.aspects;
+  const maxAspects = props.maxAspects;
+  const aspectComment = props.aspectComment;
   const [aspectTypes, setAspectTypes] = useState([]);
 
   const handleFieldChange = evt => {

--- a/src/components/character/form/CharacterForm.js
+++ b/src/components/character/form/CharacterForm.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Container, Divider, Form } from "semantic-ui-react";
+import { Container, Form } from "semantic-ui-react";
 import "../Character.css";
 import ApiManager from "../../../modules/ApiManager";
 import AspectForm from "./AspectsForm";

--- a/src/components/character/form/CharacterForm.js
+++ b/src/components/character/form/CharacterForm.js
@@ -7,6 +7,9 @@ import SkillsForm from "./SkillsForm";
 import StuntsForm from "./StuntsForm";
 import SaveCharacter from "./SaveCharacter";
 
+// DO NOT USE OR EDIT: THIS FORM HAS DEPRECATED
+// This is the old single page form, before it was stepped
+
 const CharacterForm = props => {
   // All the state for the character form is here, in the parent component
   // but modified by the handleFieldChange functions of the children components

--- a/src/components/character/form/CharacterId.js
+++ b/src/components/character/form/CharacterId.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Divider, Dropdown, Form, Message } from "semantic-ui-react";
+import { Divider, Dropdown, Form, Label } from "semantic-ui-react";
 import ApiManager from "../../../modules/ApiManager";
 import TypeDetail from "../types/TypeDetail";
 
@@ -58,8 +58,6 @@ const CharacterId = props => {
   }
 
   const handleSubTypeFieldChange = (evt, {name, value}) => {
-    console.log("name", name)
-    console.log("value", value)
     if (characterInProgress()) {
       resetCharacter();
     }
@@ -78,18 +76,6 @@ const CharacterId = props => {
   return (
     <>
       <Divider horizontal><h2>ID</h2></Divider>
-      {/* If they've already entered character information, 
-          warn them about changing character subtype
-        TODO: Make this a confirmation dialogue; that attempt was abandoned */}
-      {characterInProgress() 
-          ? <Message>
-              <Message.Header>Warning</Message.Header>
-              <p>
-                Changing character subtypes clears any character information already entered.
-              </p>
-            </Message>
-          : <></>
-        }
       <Form.Field>
         <label htmlFor="characterName">Name</label>
         <Form.Input 
@@ -102,6 +88,8 @@ const CharacterId = props => {
           placeholder="Character name"
           value={character.name}
         />
+      </Form.Field>
+      <Form.Field>
         <Dropdown 
           required
           selection
@@ -143,15 +131,24 @@ const CharacterId = props => {
                 ))}
               />
         }
-        {
-          character.subtype === ""
-          ? <></>
-          : <TypeDetail 
-              verbose={false}
-              subTypeId={parseInt(character.subtype)}
-            />
-        }
       </Form.Field>
+      {/* If they've already entered character information, 
+        warn them about changing character subtype
+        TODO: Make this a confirmation dialogue; that attempt was abandoned */}
+      {characterInProgress() 
+        ? <Label basic color="red" pointing>
+            Changing character types or subtypes clears any character information already entered.
+          </Label>
+        : <></>
+      }
+      {
+        character.subtype === ""
+        ? <></>
+        : <TypeDetail 
+            verbose={false}
+            subTypeId={parseInt(character.subtype)}
+          />
+      }
     </>
   )
 }

--- a/src/components/character/form/CharacterId.js
+++ b/src/components/character/form/CharacterId.js
@@ -9,6 +9,9 @@ const CharacterId = props => {
     stateToChange[name] = value;
     // If they're a PC, set their subtype for them
     // (there's no subtype for PCs)
+    // TODO: this could evade validation if they select PC first,
+    // then choose an NPC and leave the subtype blank 
+    // (it will still be set to subtype PC)
     if (value === "1") {
       stateToChange["subtype"] = "6";
     }

--- a/src/components/character/form/CharacterId.js
+++ b/src/components/character/form/CharacterId.js
@@ -64,8 +64,7 @@ const CharacterId = props => {
 
   useEffect(() => {
     getCharacterTypeList();
-    getCharacterSubTypeList();
-    getCharacterSubtypeDetails();
+    getCharacterSubTypeList(); 
   }, [])
 
   return (

--- a/src/components/character/form/CharacterId.js
+++ b/src/components/character/form/CharacterId.js
@@ -44,14 +44,22 @@ const CharacterId = props => {
     // (there's no subtype for PCs)
     // Otherwise, wipe any chosen subtype
     if (value === "1") {
-      stateToChange["subtype"] = "6";
+      // TODO: make this less dependent on being hard-coded
+      stateToChange["subtype"] = "6"; // 6 is the PC subtype
+      // Force a get of the subtype details:
+      getCharacterSubtypeDetails(6); 
     } else {
+      // If they're changing the character's type, 
+      // clear any chosen subtype info
       stateToChange["subtype"] = "";
+      setCharacterSubTypeDetails({});
     }
     props.setCharacter(stateToChange)
   }
 
   const handleSubTypeFieldChange = (evt, {name, value}) => {
+    console.log("name", name)
+    console.log("value", value)
     if (characterInProgress()) {
       resetCharacter();
     }

--- a/src/components/character/form/CharacterId.js
+++ b/src/components/character/form/CharacterId.js
@@ -1,8 +1,19 @@
 import React from "react";
-import { Divider, Form } from "semantic-ui-react";
+import { Divider, Dropdown, Form } from "semantic-ui-react";
 
 const CharacterId = props => {
-  const character = props.character;
+  const character = props.character; 
+
+  const handleFieldChange = (evt, {name, value}) => {
+    const stateToChange = {...character};
+    stateToChange[name] = value;
+    // If they're a PC, set their subtype for them
+    // (there's no subtype for PCs)
+    if (value === "1") {
+      stateToChange["subtype"] = "6";
+    }
+    props.setCharacter(stateToChange)
+  }
 
   return (
     <>
@@ -12,12 +23,55 @@ const CharacterId = props => {
         <Form.Input 
           type="text"
           required
-          onChange={props.handleFieldChange}
+          onChange={handleFieldChange}
           className="character"
+          name="name"
           id="name"
           placeholder="Character name"
           value={character.name}
         />
+        <Dropdown 
+          required
+          selection
+          onChange={handleFieldChange}
+          className="type"
+          name="type"
+          id="type"
+          placeholder="Character type"
+          // value={character.typeId}
+          options={props.characterTypeList.map(type => (
+            {
+              key: `type-${type.id}`,
+              value: `${type.id}`,
+              text: `${type.name}`
+            }
+          ))}
+        />
+        {// Don't display this option until a type is chosen
+          // And don't display it if they're a PC (no additional choice necessary)
+          character.type === "" || character.type === "1"
+            ? <></>
+            : <Dropdown 
+                required
+                selection
+                onChange={handleFieldChange}
+                className="subtype"
+                name="subtype"
+                id="subtype"
+                placeholder="Character Subtype"
+                value={character.subtypeId}
+                options={props.characterSubTypeList
+                  .filter(subtype => subtype.characterTypeId === parseInt(character.type))
+                  .map(type => (
+                  {
+                    key: `type-${type.id}`,
+                    value: `${type.id}`,
+                    text: `${type.name}`
+                  }
+                ))}
+              />
+        }
+        
       </Form.Field>
     </>
   )

--- a/src/components/character/form/CharacterId.js
+++ b/src/components/character/form/CharacterId.js
@@ -1,11 +1,14 @@
 import React, { useEffect, useState } from "react";
-import { Divider, Dropdown, Form } from "semantic-ui-react";
+import { Divider, Dropdown, Form, Message } from "semantic-ui-react";
 import ApiManager from "../../../modules/ApiManager";
 import TypeDetail from "../types/TypeDetail";
+import CharacterSkills from "../sheet/CharacterSkills";
 
 const CharacterId = props => {
   const character = props.character; 
   const setCharacterSubTypeDetails = props.setCharacterSubTypeDetails;
+  const resetCharacter = props.resetCharacter;
+  const characterInProgress = props.characterInProgress;
   const [characterTypeList, setCharacterTypeList] = useState([]);
   const [characterSubTypeList, setCharacterSubTypeList] = useState([]);
 
@@ -40,16 +43,19 @@ const CharacterId = props => {
     stateToChange[name] = value;
     // If they're a PC, set their subtype for them
     // (there's no subtype for PCs)
-    // TODO: this could evade validation if they select PC first,
-    // then choose an NPC and leave the subtype blank 
-    // (it will still be set to subtype PC)
+    // Otherwise, wipe any chosen subtype
     if (value === "1") {
       stateToChange["subtype"] = "6";
+    } else {
+      stateToChange["subtype"] = "";
     }
     props.setCharacter(stateToChange)
   }
 
   const handleSubTypeFieldChange = (evt, {name, value}) => {
+    if (characterInProgress()) {
+      resetCharacter();
+    }
     const stateToChange = {...character};
     stateToChange[name] = value;
     // Set subtype details in state
@@ -66,6 +72,18 @@ const CharacterId = props => {
   return (
     <>
       <Divider horizontal><h2>ID</h2></Divider>
+      {/* If they've already entered character information, 
+          warn them about changing character subtype
+        TODO: Make this a confirmation dialogue; that attempt was abandoned */}
+      {characterInProgress() 
+          ? <Message>
+              <Message.Header>Warning</Message.Header>
+              <p>
+                Changing character subtypes clears any character information already entered.
+              </p>
+            </Message>
+          : <></>
+        }
       <Form.Field>
         <label htmlFor="characterName">Name</label>
         <Form.Input 
@@ -86,7 +104,7 @@ const CharacterId = props => {
           name="type"
           id="type"
           placeholder="Character type"
-          // value={character.typeId}
+          value={character.type}
           options={characterTypeList.map(type => (
             {
               key: `type-${type.id}`,
@@ -107,7 +125,7 @@ const CharacterId = props => {
                 name="subtype"
                 id="subtype"
                 placeholder="Character Subtype"
-                value={character.subtypeId}
+                value={character.subtype}
                 options={characterSubTypeList
                   .filter(subtype => subtype.characterTypeId === parseInt(character.type))
                   .map(type => (

--- a/src/components/character/form/CharacterId.js
+++ b/src/components/character/form/CharacterId.js
@@ -5,6 +5,7 @@ import TypeDetail from "../types/TypeDetail";
 
 const CharacterId = props => {
   const character = props.character; 
+  const setCharacterSubTypeDetails = props.setCharacterSubTypeDetails;
   const [characterTypeList, setCharacterTypeList] = useState([]);
   const [characterSubTypeList, setCharacterSubTypeList] = useState([]);
   
@@ -18,6 +19,16 @@ const CharacterId = props => {
       .then(setCharacterSubTypeList)
   }
 
+  // Once a character subtype is chosen, 
+  // store all that subtype's details in state
+  // on the parent component (mainform)
+  // to be used by subsequent form components
+  const getCharacterSubtypeDetails = subtypeId => {
+    const subtype = characterSubTypeList
+      .filter(subtype => subtype.id === subtypeId)[0]
+    setCharacterSubTypeDetails(subtype);
+  }
+
   const handleFieldChange = (evt, {name, value}) => {
     const stateToChange = {...character};
     stateToChange[name] = value;
@@ -29,13 +40,17 @@ const CharacterId = props => {
     if (value === "1" && name === "type") {
       stateToChange["subtype"] = "6";
     }
+    if (name === "subtype") {
+      getCharacterSubtypeDetails(parseInt(value))
+    }
     props.setCharacter(stateToChange)
   }
 
   useEffect(() => {
     getCharacterTypeList();
     getCharacterSubTypeList();
-  }, [character])
+    getCharacterSubtypeDetails();
+  }, [])
 
   return (
     <>

--- a/src/components/character/form/CharacterId.js
+++ b/src/components/character/form/CharacterId.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Card, Divider, Dropdown, Form } from "semantic-ui-react";
+import { Divider, Dropdown, Form } from "semantic-ui-react";
 import ApiManager from "../../../modules/ApiManager";
 import TypeDetail from "../types/TypeDetail";
 
@@ -101,9 +101,6 @@ const CharacterId = props => {
               subTypeId={parseInt(character.subtype)}
             />
         }
-
-
-        
       </Form.Field>
     </>
   )

--- a/src/components/character/form/CharacterId.js
+++ b/src/components/character/form/CharacterId.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import { Divider, Dropdown, Form, Message } from "semantic-ui-react";
 import ApiManager from "../../../modules/ApiManager";
 import TypeDetail from "../types/TypeDetail";
-import CharacterSkills from "../sheet/CharacterSkills";
 
 const CharacterId = props => {
   const character = props.character; 

--- a/src/components/character/form/CharacterId.js
+++ b/src/components/character/form/CharacterId.js
@@ -8,7 +8,7 @@ const CharacterId = props => {
   const setCharacterSubTypeDetails = props.setCharacterSubTypeDetails;
   const [characterTypeList, setCharacterTypeList] = useState([]);
   const [characterSubTypeList, setCharacterSubTypeList] = useState([]);
-  
+
   const getCharacterTypeList = () => {
     return ApiManager.getAll("characterTypes")
       .then(setCharacterTypeList)
@@ -29,7 +29,13 @@ const CharacterId = props => {
     setCharacterSubTypeDetails(subtype);
   }
 
-  const handleFieldChange = (evt, {name, value}) => {
+  const handleNameFieldChange = (evt, {name, value}) => {
+    const stateToChange = {...character};
+    stateToChange[name] = value;
+    props.setCharacter(stateToChange)
+  }
+
+  const handleTypeFieldChange = (evt, {name, value}) => {
     const stateToChange = {...character};
     stateToChange[name] = value;
     // If they're a PC, set their subtype for them
@@ -37,12 +43,17 @@ const CharacterId = props => {
     // TODO: this could evade validation if they select PC first,
     // then choose an NPC and leave the subtype blank 
     // (it will still be set to subtype PC)
-    if (value === "1" && name === "type") {
+    if (value === "1") {
       stateToChange["subtype"] = "6";
     }
-    if (name === "subtype") {
-      getCharacterSubtypeDetails(parseInt(value))
-    }
+    props.setCharacter(stateToChange)
+  }
+
+  const handleSubTypeFieldChange = (evt, {name, value}) => {
+    const stateToChange = {...character};
+    stateToChange[name] = value;
+    // Set subtype details in state
+    getCharacterSubtypeDetails(parseInt(value))
     props.setCharacter(stateToChange)
   }
 
@@ -60,7 +71,7 @@ const CharacterId = props => {
         <Form.Input 
           type="text"
           required
-          onChange={handleFieldChange}
+          onChange={handleNameFieldChange}
           className="character"
           name="name"
           id="name"
@@ -70,7 +81,7 @@ const CharacterId = props => {
         <Dropdown 
           required
           selection
-          onChange={handleFieldChange}
+          onChange={handleTypeFieldChange}
           className="type"
           name="type"
           id="type"
@@ -91,7 +102,7 @@ const CharacterId = props => {
             : <Dropdown 
                 required
                 selection
-                onChange={handleFieldChange}
+                onChange={handleSubTypeFieldChange}
                 className="subtype"
                 name="subtype"
                 id="subtype"

--- a/src/components/character/form/CharacterId.js
+++ b/src/components/character/form/CharacterId.js
@@ -1,8 +1,22 @@
-import React from "react";
-import { Divider, Dropdown, Form } from "semantic-ui-react";
+import React, { useEffect, useState } from "react";
+import { Card, Divider, Dropdown, Form } from "semantic-ui-react";
+import ApiManager from "../../../modules/ApiManager";
+import TypeDetail from "../types/TypeDetail";
 
 const CharacterId = props => {
   const character = props.character; 
+  const [characterTypeList, setCharacterTypeList] = useState([]);
+  const [characterSubTypeList, setCharacterSubTypeList] = useState([]);
+  
+  const getCharacterTypeList = () => {
+    return ApiManager.getAll("characterTypes")
+      .then(setCharacterTypeList)
+  }
+
+  const getCharacterSubTypeList = () => {
+    return ApiManager.getAll("characterSubTypes")
+      .then(setCharacterSubTypeList)
+  }
 
   const handleFieldChange = (evt, {name, value}) => {
     const stateToChange = {...character};
@@ -12,11 +26,16 @@ const CharacterId = props => {
     // TODO: this could evade validation if they select PC first,
     // then choose an NPC and leave the subtype blank 
     // (it will still be set to subtype PC)
-    if (value === "1") {
+    if (value === "1" && name === "type") {
       stateToChange["subtype"] = "6";
     }
     props.setCharacter(stateToChange)
   }
+
+  useEffect(() => {
+    getCharacterTypeList();
+    getCharacterSubTypeList();
+  }, [character])
 
   return (
     <>
@@ -42,7 +61,7 @@ const CharacterId = props => {
           id="type"
           placeholder="Character type"
           // value={character.typeId}
-          options={props.characterTypeList.map(type => (
+          options={characterTypeList.map(type => (
             {
               key: `type-${type.id}`,
               value: `${type.id}`,
@@ -63,7 +82,7 @@ const CharacterId = props => {
                 id="subtype"
                 placeholder="Character Subtype"
                 value={character.subtypeId}
-                options={props.characterSubTypeList
+                options={characterSubTypeList
                   .filter(subtype => subtype.characterTypeId === parseInt(character.type))
                   .map(type => (
                   {
@@ -74,6 +93,16 @@ const CharacterId = props => {
                 ))}
               />
         }
+        {
+          character.subtype === ""
+          ? <></>
+          : <TypeDetail 
+              verbose={false}
+              subTypeId={parseInt(character.subtype)}
+            />
+        }
+
+
         
       </Form.Field>
     </>

--- a/src/components/character/form/EditCharacter.js
+++ b/src/components/character/form/EditCharacter.js
@@ -12,6 +12,7 @@ import ApiManager from "../../../modules/ApiManager";
 const EditCharacter = props => {
   const characterId = props.characterId;
   const setCharacter = props.setCharacter;
+  const setCharacterSubTypeDetails = props.setCharacterSubTypeDetails;
 
   const characterAspects = props.characterAspects;
   const setCharacterAspects = props.setCharacterAspects;
@@ -38,19 +39,17 @@ const EditCharacter = props => {
   }
 
   const setCharacterToEdit = (character) => {
-    console.log(character)   
     const subtype = character.characterSubTypeId;
     const type = character.characterSubType.characterTypeId;
-
     const characterToEdit = {
       name: character.name, 
       type: `${type}`, 
       subtype: `${subtype}`,
-      created: character.created
+      created: character.created,
+      id: characterId
     }
-    console.log(characterToEdit)
-
     setCharacter(characterToEdit);
+    setCharacterSubTypeDetails(character.characterSubType);
   }
   
   const setAspectsToEdit = (aspects) => {

--- a/src/components/character/form/EditCharacter.js
+++ b/src/components/character/form/EditCharacter.js
@@ -1,21 +1,33 @@
 import React, { useEffect } from "react";
 import ApiManager from "../../../modules/ApiManager";
 
+/*
+  This component is only rendered on the MainForm 
+  if a character is being edited.
+  
+  It retrieves all of that character's data from the
+  database and puts it in state in the format of the form
+*/
+
 const EditCharacter = props => {
   const characterId = props.characterId;
   const setCharacter = props.setCharacter;
+
   const characterAspects = props.characterAspects;
   const setCharacterAspects = props.setCharacterAspects;
+  
   const characterSkills = props.characterSkills;
   const setCharacterSkills = props.setCharacterSkills;
+  
   const characterStunts = props.characterStunts;
   const setCharacterStunts = props.setCharacterStunts;
+  
   const setIsLoading = props.setIsLoading;
 
   const editSetup = () => {
-    // Get alll of the characters' data and put it in state
-    ApiManager.get("characters", characterId)
-      .then(character => setCharacter(character))
+    // Get all of the characters' data and put it in state
+    ApiManager.getCharacterWithType(characterId)
+      .then(character => setCharacterToEdit(character))
     ApiManager.getCharacterAspects(characterId)
       .then(aspects => setAspectsToEdit(aspects))
     ApiManager.getCharacterSkills(characterId)
@@ -23,6 +35,22 @@ const EditCharacter = props => {
     ApiManager.getCharacterStunts(characterId)
       .then(stunts => setStuntsToEdit(stunts))
       .then(() => setIsLoading(false))
+  }
+
+  const setCharacterToEdit = (character) => {
+    console.log(character)   
+    const subtype = character.characterSubTypeId;
+    const type = character.characterSubType.characterTypeId;
+
+    const characterToEdit = {
+      name: character.name, 
+      type: `${type}`, 
+      subtype: `${subtype}`,
+      created: character.created
+    }
+    console.log(characterToEdit)
+
+    setCharacter(characterToEdit);
   }
   
   const setAspectsToEdit = (aspects) => {

--- a/src/components/character/form/MainForm.js
+++ b/src/components/character/form/MainForm.js
@@ -121,6 +121,9 @@ const MainForm = props => {
         if (character.name === "") {
           validationConfirm("Enter a character name")
           return false
+        } else if (character.subtype === "") {
+          validationConfirm("Enter a character type & subtype")
+          return false
         } else {
           return true
         }

--- a/src/components/character/form/MainForm.js
+++ b/src/components/character/form/MainForm.js
@@ -201,6 +201,7 @@ const MainForm = props => {
         />
       case 2: 
         return <AspectForm
+          type={characterSubTypeDetails.name}
           aspects={characterAspects}
           setAspects={setCharacterAspects}
           maxAspects={characterSubTypeDetails.maxAspects}

--- a/src/components/character/form/MainForm.js
+++ b/src/components/character/form/MainForm.js
@@ -79,21 +79,6 @@ const MainForm = props => {
     })
   }
 
-  const characterInProgress = () => {
-    if (characterAspects[0].name !== "" 
-        || characterSkills[1].length > 0
-        || characterStunts[1] !== ""
-    ) {
-    console.log("characterAspects[0].name", characterAspects[0].name)
-    console.log("characterSkills[1].length", characterSkills[1].length)
-    console.log("characterStunts[1]", characterStunts[1])
-    return true
-    } else {
-      return false
-    }
-    
-  }
-
   /* ------------------ GETS & STATE SETS  ------------------*/
   const getSkillList = () => {
     return ApiManager.getAll("skills")
@@ -130,6 +115,17 @@ const MainForm = props => {
 
   /* ------------------ VALIDATIONS  ------------------*/
   // TODO: these are duplicated here and in SaveCharacter
+
+  const characterInProgress = () => {
+    if (characterAspects[0].name !== "" 
+        || characterSkills[1].length > 0
+        || characterStunts[1] !== ""
+    ) {
+    return true
+    } else {
+      return false
+    }
+  }
 
   const validationConfirm = (message) => {
     confirmAlert({
@@ -293,11 +289,6 @@ const MainForm = props => {
   useEffect(() => {
     getSkillList();
     getStuntList();
-    // AKA: if this is an edit
-    if (props.match.params.characterId) {
-      ApiManager.get("characters", props.match.params.characterId)
-        .then(character => setCharacter(character))
-    }
     setIsLoading(false);
   }, [])
 
@@ -317,6 +308,7 @@ const MainForm = props => {
             characterStunts={characterStunts}
             setCharacterStunts={setCharacterStunts}
             setIsLoading={setIsLoading}
+            setCharacterSubTypeDetails={setCharacterSubTypeDetails}
           />
           : <></>
         }

--- a/src/components/character/form/MainForm.js
+++ b/src/components/character/form/MainForm.js
@@ -21,6 +21,7 @@ const MainForm = props => {
   const [stuntList, setStuntList] = useState([]);
 
   const [character, setCharacter] = useState({name: "", type: "", subtype: ""});
+  const [characterSubTypeDetails, setCharacterSubTypeDetails] = useState();
 
   // Seeding a default array of aspects
   // presently with their types (currently) hard coded
@@ -196,11 +197,14 @@ const MainForm = props => {
         return <CharacterId 
           character={character} 
           setCharacter={setCharacter}
+          setCharacterSubTypeDetails={setCharacterSubTypeDetails}
         />
       case 2: 
         return <AspectForm
           aspects={characterAspects}
           setAspects={setCharacterAspects}
+          maxAspects={characterSubTypeDetails.maxAspects}
+          aspectComment={characterSubTypeDetails.aspectComment}
         />
       case 3: 
         return <SkillsForm 

--- a/src/components/character/form/MainForm.js
+++ b/src/components/character/form/MainForm.js
@@ -213,6 +213,10 @@ const MainForm = props => {
           setSkillList={setSkillList}
           characterSkills={characterSkills}
           setCharacterSkills={setCharacterSkills}
+          maxSkillRating={characterSubTypeDetails.maxSkillRating}
+          skillRatingComment={characterSubTypeDetails.skillRatingComment}
+          skillChoiceComment={characterSubTypeDetails.skillChoiceComment}
+          type={characterSubTypeDetails.name}
         />
       case 4: 
         return <StuntsForm
@@ -221,6 +225,9 @@ const MainForm = props => {
           skillList={skillList}
           stuntList={stuntList}
           setStuntList={setStuntList}
+          type={characterSubTypeDetails.name}
+          maxStunts={characterSubTypeDetails.maxStunts}
+          stuntComment={characterSubTypeDetails.stuntComment}
         />
       case 5:
         return <>

--- a/src/components/character/form/MainForm.js
+++ b/src/components/character/form/MainForm.js
@@ -51,6 +51,49 @@ const MainForm = props => {
     1: ""
   });
 
+  // TODO: utilize useReducer instead
+  // https://reactjs.org/docs/hooks-reference.html#usereducer
+  const resetCharacter = () => {
+    setCharacterAspects([
+      { name: "", aspectTypeId: 1 },
+      { name: "", aspectTypeId: 2 },
+      { name: "", aspectTypeId: 3 },    
+      { name: "", aspectTypeId: 3 },
+      { name: "", aspectTypeId: 3 },
+      { name: "", aspectTypeId: 3 }
+    ]);
+    setCharacterSkills({
+      6: [],
+      5: [],
+      4: [],
+      3: [],
+      2: [],
+      1: []
+    });
+    setCharacterStunts({
+      5: "",
+      4: "",
+      3: "",
+      2: "",
+      1: ""
+    })
+  }
+
+  const characterInProgress = () => {
+    if (characterAspects[0].name !== "" 
+        || characterSkills[1].length > 0
+        || characterStunts[1] !== ""
+    ) {
+    console.log("characterAspects[0].name", characterAspects[0].name)
+    console.log("characterSkills[1].length", characterSkills[1].length)
+    console.log("characterStunts[1]", characterStunts[1])
+    return true
+    } else {
+      return false
+    }
+    
+  }
+
   /* ------------------ GETS & STATE SETS  ------------------*/
   const getSkillList = () => {
     return ApiManager.getAll("skills")
@@ -198,6 +241,8 @@ const MainForm = props => {
           character={character} 
           setCharacter={setCharacter}
           setCharacterSubTypeDetails={setCharacterSubTypeDetails}
+          characterInProgress={characterInProgress}
+          resetCharacter={resetCharacter}
         />
       case 2: 
         return <AspectForm

--- a/src/components/character/form/MainForm.js
+++ b/src/components/character/form/MainForm.js
@@ -239,6 +239,9 @@ const MainForm = props => {
               stunts={characterStunts}
               skillList={skillList}
               stuntList={stuntList}
+              type={characterSubTypeDetails.name}
+              stressMax={characterSubTypeDetails.stressMax}
+              bothStressTypes={characterSubTypeDetails.bothStressTypes}
             />
         </>
     }

--- a/src/components/character/form/MainForm.js
+++ b/src/components/character/form/MainForm.js
@@ -20,7 +20,7 @@ const MainForm = props => {
   const [skillList, setSkillList] = useState([]);
   const [stuntList, setStuntList] = useState([]);
 
-  const [character, setCharacter] = useState({name: ""});
+  const [character, setCharacter] = useState({name: "", type: "", subtype: ""});
 
   // Seeding a default array of aspects
   // presently with their types (currently) hard coded
@@ -50,6 +50,9 @@ const MainForm = props => {
     1: ""
   });
 
+  const [characterTypeList, setCharacterTypeList] = useState([]);
+  const [characterSubTypeList, setCharacterSubTypeList] = useState([]);
+
 
   /* ------------------ GETS & STATE SETS  ------------------*/
   const getSkillList = () => {
@@ -65,14 +68,17 @@ const MainForm = props => {
       .then(setStuntList); 
   }
 
-
-  // Note: Most field changes are handled 
-  // by their respective child components
-  const handleFieldChange = evt => {
-    const stateToChange = {...character};
-    stateToChange[evt.target.id] = evt.target.value;
-    setCharacter(stateToChange)
+  const getCharacterTypeList = () => {
+    return ApiManager.getAll("characterTypes")
+      .then(setCharacterTypeList)
   }
+
+  const getCharacterSubTypeList = () => {
+    return ApiManager.getAll("characterSubTypes")
+      .then(setCharacterSubTypeList)
+  }
+
+  /* ------------------ EVENT HANDLERS  ------------------*/
 
   const handleItemClick = (evt, {index}) => {
     if (validStep()) {
@@ -200,7 +206,9 @@ const MainForm = props => {
       case 1:
         return <CharacterId 
           character={character} 
-          handleFieldChange={handleFieldChange}
+          setCharacter={setCharacter}
+          characterTypeList={characterTypeList}
+          characterSubTypeList={characterSubTypeList}
         />
       case 2: 
         return <AspectForm
@@ -240,6 +248,8 @@ const MainForm = props => {
   useEffect(() => {
     getSkillList();
     getStuntList();
+    getCharacterTypeList();
+    getCharacterSubTypeList();
     // AKA: if this is an edit
     if (props.match.params.characterId) {
       ApiManager.get("characters", props.match.params.characterId)

--- a/src/components/character/form/MainForm.js
+++ b/src/components/character/form/MainForm.js
@@ -50,10 +50,6 @@ const MainForm = props => {
     1: ""
   });
 
-  const [characterTypeList, setCharacterTypeList] = useState([]);
-  const [characterSubTypeList, setCharacterSubTypeList] = useState([]);
-
-
   /* ------------------ GETS & STATE SETS  ------------------*/
   const getSkillList = () => {
     return ApiManager.getAll("skills")
@@ -66,16 +62,6 @@ const MainForm = props => {
         https://stackoverflow.com/a/45544166*/
       .then(stuntList => stuntList.sort((a, b) => a.name.localeCompare(b.name) ))
       .then(setStuntList); 
-  }
-
-  const getCharacterTypeList = () => {
-    return ApiManager.getAll("characterTypes")
-      .then(setCharacterTypeList)
-  }
-
-  const getCharacterSubTypeList = () => {
-    return ApiManager.getAll("characterSubTypes")
-      .then(setCharacterSubTypeList)
   }
 
   /* ------------------ EVENT HANDLERS  ------------------*/
@@ -210,8 +196,6 @@ const MainForm = props => {
         return <CharacterId 
           character={character} 
           setCharacter={setCharacter}
-          characterTypeList={characterTypeList}
-          characterSubTypeList={characterSubTypeList}
         />
       case 2: 
         return <AspectForm
@@ -251,8 +235,6 @@ const MainForm = props => {
   useEffect(() => {
     getSkillList();
     getStuntList();
-    getCharacterTypeList();
-    getCharacterSubTypeList();
     // AKA: if this is an edit
     if (props.match.params.characterId) {
       ApiManager.get("characters", props.match.params.characterId)

--- a/src/components/character/form/MainForm.js
+++ b/src/components/character/form/MainForm.js
@@ -239,9 +239,7 @@ const MainForm = props => {
               stunts={characterStunts}
               skillList={skillList}
               stuntList={stuntList}
-              type={characterSubTypeDetails.name}
-              stressMax={characterSubTypeDetails.stressMax}
-              bothStressTypes={characterSubTypeDetails.bothStressTypes}
+              characterSubType={characterSubTypeDetails}
             />
         </>
     }

--- a/src/components/character/form/SaveCharacter.js
+++ b/src/components/character/form/SaveCharacter.js
@@ -13,12 +13,14 @@ const SaveCharacter = props => {
   const isEdit = props.match.params.characterId ? true : false;
   const setIsLoading= props.setIsLoading;
 
+  // NOTE: JSON.parse is the reverse of JSON.stringify
+  const user = JSON.parse(sessionStorage.getItem("credentials"));
+
   /* ------------ OBJECT CONSTRUCTORS ------------ */
   const constructCharacter = () => {
-    // NOTE: JSON.parse is the reverse of JSON.stringify
-    const user = JSON.parse(sessionStorage.getItem("credentials"));
     const characterToSave = {
       name: character.name,
+      characterSubTypeId: parseInt(character.subtype),
       userId: user.id,
       created: new Date().toLocaleString(),
       modified: new Date().toLocaleString()

--- a/src/components/character/form/SheetReview.js
+++ b/src/components/character/form/SheetReview.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
 import SheetPreview from "../sheet/SheetPreview";
 
-//Sheet Review will format all the information properly to 
-// run it through the preview
+/*Sheet Review formats the information saved in state
+  for a character-in-progress (either edited or created)  
+  and then passes it on to the sheet preview rendering component */
 
 const SheetReview = props => {
   const characterSubType = props.characterSubType

--- a/src/components/character/form/SheetReview.js
+++ b/src/components/character/form/SheetReview.js
@@ -5,15 +5,13 @@ import SheetPreview from "../sheet/SheetPreview";
 // run it through the preview
 
 const SheetReview = props => {
+  const characterSubType = props.characterSubType
   const character = props.character;
   const aspects = props.aspects;
   const skills = props.skills;
   const stunts = props.stunts;
   const skillList = props.skillList;
   const stuntList = props.stuntList;
-  const type = props.type;
-  const bothStressTypes = props.bothStressTypes;
-  const stressMax = props.stressMax;
   
   const [willRating, setWillRating] = useState();
   const [physiqueRating, setPhysiqueRating] = useState();
@@ -96,9 +94,7 @@ const SheetReview = props => {
         stunts={characterStuntDetails}
         physiqueRating={physiqueRating}
         willRating={willRating}
-        stressMax={stressMax}
-        bothStressTypes={bothStressTypes}
-        type={type}
+        characterSubType={characterSubType}
       />
     </>
   )

--- a/src/components/character/form/SheetReview.js
+++ b/src/components/character/form/SheetReview.js
@@ -11,6 +11,9 @@ const SheetReview = props => {
   const stunts = props.stunts;
   const skillList = props.skillList;
   const stuntList = props.stuntList;
+  const type = props.type;
+  const bothStressTypes = props.bothStressTypes;
+  const stressMax = props.stressMax;
   
   const [willRating, setWillRating] = useState();
   const [physiqueRating, setPhysiqueRating] = useState();
@@ -85,14 +88,19 @@ const SheetReview = props => {
   }, [])
 
   return (
-    <SheetPreview
-      character={character}
-      aspects={aspects}
-      skills={characterSkillNames}
-      stunts={characterStuntDetails}
-      physiqueRating={physiqueRating}
-      willRating={willRating}
-    />
+    <>
+      <SheetPreview
+        character={character}
+        aspects={aspects}
+        skills={characterSkillNames}
+        stunts={characterStuntDetails}
+        physiqueRating={physiqueRating}
+        willRating={willRating}
+        stressMax={stressMax}
+        bothStressTypes={bothStressTypes}
+        type={type}
+      />
+    </>
   )
 }
 

--- a/src/components/character/form/SkillsDropDown.js
+++ b/src/components/character/form/SkillsDropDown.js
@@ -7,6 +7,7 @@
       <>
         {/* <div className="skill-selector"> */}
           <Dropdown
+            clearable
             placeholder="Filter by related skill"
             selection
             id={`${props.x}:${props.y}`}

--- a/src/components/character/form/SkillsForm.js
+++ b/src/components/character/form/SkillsForm.js
@@ -1,8 +1,12 @@
 import React from "react";
-import { Divider } from "semantic-ui-react";
+import { Divider, Grid } from "semantic-ui-react";
 import SkillsMultiSelector from "./SkillsMultiSelector"
 
 const SkillsForm = props => {
+  const type = props.type;
+  const maxSkillRating = props.maxSkillRating;
+  const skillRatingComment = props.skillRatingComment;
+  const skillChoiceComment = props.skillChoiceComment;
   const setCharacterSkills = props.setCharacterSkills;
   const characterSkills = props.characterSkills;
   
@@ -16,17 +20,38 @@ const SkillsForm = props => {
     setCharacterSkills(stateToChange);
     };
 
+  const createSkillSelectors = () => {
+    let skillSelectors = [];
+    for (let i = 1; i <= maxSkillRating; i++) {
+      /* Using this row prop to determine the "rating" 
+        of a particular chosen skill */
+      skillSelectors.push(
+        <SkillsMultiSelector 
+          row={`${i}`} 
+          skillList={props.skillList} 
+          characterSkills={characterSkills} 
+          handleFieldChange={handleFieldChange} 
+        /> 
+      )
+    }
+    // Reverse the order so the highest skill rating is at the top
+    return skillSelectors.reverse();
+  }
+
   return (
     <>
       <Divider horizontal><h2>SKILLS</h2></Divider>
-      {/* Using this row prop to determine the "rating" of a particular chosen skill */}
-      {/* TODO: figure out how to loop this so you only write it once and can generate more dynamically*/}
-      <SkillsMultiSelector row="6" skillList={props.skillList} characterSkills={characterSkills} handleFieldChange={handleFieldChange} /> 
-      <SkillsMultiSelector row="5" skillList={props.skillList} characterSkills={characterSkills} handleFieldChange={handleFieldChange} /> 
-      <SkillsMultiSelector row="4" skillList={props.skillList} characterSkills={characterSkills} handleFieldChange={handleFieldChange} /> 
-      <SkillsMultiSelector row="3" skillList={props.skillList} characterSkills={characterSkills} handleFieldChange={handleFieldChange} /> 
-      <SkillsMultiSelector row="2" skillList={props.skillList} characterSkills={characterSkills} handleFieldChange={handleFieldChange} /> 
-      <SkillsMultiSelector row="1" skillList={props.skillList} characterSkills={characterSkills} handleFieldChange={handleFieldChange} /> 
+      <Grid columns={2}>
+        <Grid.Column width={10}>
+          {createSkillSelectors()}
+        </Grid.Column>
+        <Grid.Column width={6}>
+          {/* TODO: make this look cleaner on render */}
+          <h3>Skills for {type}</h3>
+          <p>{skillRatingComment}</p>
+          <p>{skillChoiceComment}</p>
+        </Grid.Column>
+      </Grid>
     </>
   )
 }

--- a/src/components/character/form/StuntRow.js
+++ b/src/components/character/form/StuntRow.js
@@ -1,11 +1,11 @@
-import React from "react";
-import { Form, Grid } from "semantic-ui-react";
+import React, { useState } from "react";
+import { Grid } from "semantic-ui-react";
 import StuntsDropdown from "./StuntsDropdown";
 import StuntDescription from "./StuntsDescription";
 import SkillsDropDown from "./SkillsDropDown";
 
 const StuntRow = props => {
-  const setFilter = props.setFilter;
+  const [filter, setFilter] = useState("")
 
   const handleFilter = (evt, {name, value}) => {
     const valueToSet = parseInt(value)
@@ -30,7 +30,7 @@ const StuntRow = props => {
               setStuntList={props.setStuntList} 
               characterStunts={props.characterStunts} 
               setCharacterStunts={props.setCharacterStunts} 
-              filter={props.filter}
+              filter={filter}
             />
           </Grid.Column>
         </Grid.Row>

--- a/src/components/character/form/StuntRow.js
+++ b/src/components/character/form/StuntRow.js
@@ -8,8 +8,14 @@ const StuntRow = props => {
   const [filter, setFilter] = useState("")
 
   const handleFilter = (evt, {name, value}) => {
-    const valueToSet = parseInt(value)
-    setFilter(valueToSet)
+    // Blank values (from utilizing the clearable x)
+    // set the filter back to its default state
+    if (!value) {
+      setFilter("")
+    } else {
+      const valueToSet = parseInt(value)
+      setFilter(valueToSet)
+    }
   }
 
   return (

--- a/src/components/character/form/StuntsDropdown.js
+++ b/src/components/character/form/StuntsDropdown.js
@@ -24,6 +24,7 @@ const StuntsDropdown = props => {
     <>
       {/* <div className="stunt-selector"> */}
         <Dropdown
+          clearable
           placeholder="Select Stunt"
           selection
           id={`stunts--${props.x}`}

--- a/src/components/character/form/StuntsForm.js
+++ b/src/components/character/form/StuntsForm.js
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import { Divider } from "semantic-ui-react";
+import React from "react";
+import { Divider, Grid } from "semantic-ui-react";
 
 import StuntRow from "./StuntRow";
 import "../Character.css";
@@ -9,72 +9,42 @@ const StuntsForm = props => {
   const characterStunts = props.characterStunts;
   const stuntList = props.stuntList;
   const setStuntList = props.setStuntList;
+  const type = props.type;
+  const maxStunts = props.maxStunts;
+  const stuntComment = props.stuntComment;
 
-  const [filter1, setFilter1] = useState("");
-  const [filter2, setFilter2] = useState("");
-  const [filter3, setFilter3] = useState("");
-  const [filter4, setFilter4] = useState("");
-  const [filter5, setFilter5] = useState("");
+  const createStuntRow = () => {
+    let stuntRows = [];
+    for (let i = 1; i <= maxStunts; i++) {
+      stuntRows.push(
+        <StuntRow 
+          x={`${i}`}  
+          stuntList={stuntList} 
+          setStuntList={setStuntList} 
+          characterStunts={characterStunts} 
+          setCharacterStunts={setCharacterStunts} 
+          skillList={props.skillList}
+        />
+      )
+    }
+    return stuntRows;
+  }
 
-  // FIXME: ??
-  useEffect(() => {
-  
-  }, [filter1, filter2, filter3, filter4, filter5])
-
-  // TODO: Make this DRY
   return (
     <>
       <Divider horizontal><h2>STUNTS</h2></Divider>
-      <p>(choose a skill to filter by)</p>
-      <StuntRow 
-        x="1" 
-        filter={filter1} 
-        setFilter={setFilter1} 
-        stuntList={stuntList} 
-        setStuntList={setStuntList} 
-        characterStunts={characterStunts} 
-        setCharacterStunts={setCharacterStunts} 
-        skillList={props.skillList}
-      />
-      <StuntRow 
-        x="2" 
-        filter={filter2} 
-        setFilter={setFilter2} 
-        stuntList={stuntList} 
-        setStuntList={setStuntList} 
-        characterStunts={characterStunts} 
-        setCharacterStunts={setCharacterStunts} 
-        skillList={props.skillList}
-      />
-      <StuntRow 
-        x="3" 
-        filter={filter3} 
-        setFilter={setFilter3} 
-        stuntList={stuntList} 
-        setStuntList={setStuntList} 
-        characterStunts={characterStunts} 
-        setCharacterStunts={setCharacterStunts} 
-        skillList={props.skillList}
-      />
-      <StuntRow 
-        x="4" 
-        filter={filter4} 
-        setFilter={setFilter4} 
-        stuntList={stuntList} 
-        setStuntList={setStuntList} 
-        characterStunts={characterStunts} 
-        setCharacterStunts={setCharacterStunts} 
-        skillList={props.skillList}
-      />
-      <StuntRow 
-        x="5" 
-        filter={filter5} 
-        setFilter={setFilter5} 
-        stuntList={stuntList} 
-        setStuntList={setStuntList} 
-        characterStunts={characterStunts} 
-        setCharacterStunts={setCharacterStunts} 
-        skillList={props.skillList}/>
+      <Grid columns={2}>
+        <Grid.Column width={10}>
+          <p>(choose a skill to filter by)</p>
+          {createStuntRow()}
+        </Grid.Column>
+        <Grid.Column width={6}>
+          {/* TODO: make this look cleaner on render */}
+          <h3>Stunts for {type}</h3>
+          <p>{stuntComment}</p>
+        </Grid.Column>
+      </Grid>
+      
     </>
   )
 }

--- a/src/components/character/form/StuntsForm.js
+++ b/src/components/character/form/StuntsForm.js
@@ -33,18 +33,24 @@ const StuntsForm = props => {
   return (
     <>
       <Divider horizontal><h2>STUNTS</h2></Divider>
-      <Grid columns={2}>
-        <Grid.Column width={10}>
-          <p>(choose a skill to filter by)</p>
-          {createStuntRow()}
-        </Grid.Column>
-        <Grid.Column width={6}>
-          {/* TODO: make this look cleaner on render */}
-          <h3>Stunts for {type}</h3>
-          <p>{stuntComment}</p>
-        </Grid.Column>
-      </Grid>
-      
+        <Grid columns={2}>
+          <Grid.Column width={10}>
+            {/* If a character subtype requires no stunts,
+              do not render the component for them to choose one */}
+            {maxStunts > 0
+              ? <>
+                  <p>(choose a skill to filter by)</p>
+                  {createStuntRow()}
+                </>
+              : <></>
+            }
+          </Grid.Column>
+          <Grid.Column width={6}>
+            {/* TODO: make this look cleaner on render */}
+            <h3>Stunts for {type}</h3>
+            <p>{stuntComment}</p>
+          </Grid.Column>
+        </Grid>
     </>
   )
 }

--- a/src/components/character/sheet/CharacterSheet.js
+++ b/src/components/character/sheet/CharacterSheet.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { confirmAlert } from 'react-confirm-alert';
-import { Container, Button, Divider, Grid, Icon, Segment } from "semantic-ui-react"
+import { Container, Button, Icon} from "semantic-ui-react"
 import 'react-confirm-alert/src/react-confirm-alert.css'; 
 import ApiManager from "../../../modules/ApiManager";
 import CharacterMeta from "./CharacterMeta";
@@ -31,7 +31,6 @@ const CharacterSheet = props => {
     ApiManager.getCharacterWithType(id)
       .then(character => {
         setCharacter(character)
-        console.log("character.characterSubType", character.characterSubType)
         setCharacterSubType(character.characterSubType)
       });
   }

--- a/src/components/character/sheet/CharacterSheet.js
+++ b/src/components/character/sheet/CharacterSheet.js
@@ -9,6 +9,7 @@ import SheetPreview from "./SheetPreview";
 
 const CharacterSheet = props => {
   const [character, setCharacter] = useState({});
+  const [characterSubType, setCharacterSubType] = useState({});
   const [aspects, setAspects] = useState([]);
   const [skills, setSkills] = useState({
     6: [],
@@ -21,15 +22,18 @@ const CharacterSheet = props => {
   const [physiqueRating, setPhysiqueRating] = useState({});
   const [willRating, setWillRating] = useState({});
   const [stunts, setStunts] = useState([]);
-
   const [isLoading, setIsLoading] = useState(true);
   
   const activeUser = JSON.parse(sessionStorage.getItem("credentials"));
   const id = props.characterId;
 
   const getCharacter = () => {
-    ApiManager.get("characters", id)
-      .then(setCharacter);
+    ApiManager.getCharacterWithType(id)
+      .then(character => {
+        setCharacter(character)
+        console.log("character.characterSubType", character.characterSubType)
+        setCharacterSubType(character.characterSubType)
+      });
   }
 
   const getAspects = () => {
@@ -110,6 +114,7 @@ const CharacterSheet = props => {
           stunts={stunts}
           physiqueRating={physiqueRating}
           willRating={willRating}
+          characterSubType={characterSubType}
         />
           {/* Conditionally rendering these buttons 
             if the user created this character */}

--- a/src/components/character/sheet/CharacterSkills.js
+++ b/src/components/character/sheet/CharacterSkills.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Divider, List, Label } from "semantic-ui-react";
+import { Divider, List } from "semantic-ui-react";
 import CharacterSkillRow from "./CharacterSkillRow"
 
 const CharacterSkills = props => {

--- a/src/components/character/sheet/ConsequenceInputs.js
+++ b/src/components/character/sheet/ConsequenceInputs.js
@@ -1,6 +1,13 @@
 import React from "react";
 import { Grid, Icon, Input, Popup } from "semantic-ui-react";
 
+/* 
+  ConsequenceInputs determines the amount of consequence inputs to render
+  on a character sheet based on 
+    - the character's will/physique ratings 
+    - the character type's maxConsequences value
+*/
+
 const ConsequenceInputs = props => {
   const willRating = props.willRating;
   const physiqueRating = props.physiqueRating;
@@ -8,11 +15,6 @@ const ConsequenceInputs = props => {
   const type = props.type;
   const maxConsequence = props.maxConsequence;
   const consequenceComment = props.consequenceComment;
-
-  // TODO: limit max consequences
-  // TODO: include a consequence comment
-
-
 
   // If skill rating is 5+, they also get an extra mild consequence slot 
   const extraInputs = (stressType) => {

--- a/src/components/character/sheet/ConsequenceInputs.js
+++ b/src/components/character/sheet/ConsequenceInputs.js
@@ -1,9 +1,18 @@
 import React from "react";
-import { Grid, Input, Segment } from "semantic-ui-react";
+import { Grid, Icon, Input, Popup } from "semantic-ui-react";
 
 const ConsequenceInputs = props => {
   const willRating = props.willRating;
   const physiqueRating = props.physiqueRating;
+
+  const type = props.type;
+  const maxConsequence = props.maxConsequence;
+  const consequenceComment = props.consequenceComment;
+
+  // TODO: limit max consequences
+  // TODO: include a consequence comment
+
+
 
   // If skill rating is 5+, they also get an extra mild consequence slot 
   const extraInputs = (stressType) => {
@@ -24,16 +33,70 @@ const ConsequenceInputs = props => {
 
   return (
     <>
-        <p><strong>CONSEQUENCES</strong></p>
-        <Grid stackable>
-          <Grid.Column width={6}>
-            {extraInputs("physical")}
-            {extraInputs("mental")}
-            <Input label="2" placeholder="Mild"/>
-            <Input label="4" placeholder="Moderate"/>
-            <Input label="6" placeholder="Severe"/>
-          </Grid.Column>
-        </Grid>
+      {/* If the character's type has no consequence, 
+          don't render any */}
+      {maxConsequence > 0 
+        ? <>
+            <h4>
+              CONSEQUENCES
+              {/* A popup explains the logic behind a character's consequences */}
+              <Popup
+                basic
+                trigger={<Icon className="info circle large"/>}
+                header={type} 
+                content={
+                  <>
+                    <p>
+                      {consequenceComment}
+                    </p>
+                  </>
+                }
+                />
+            </h4>
+            <Grid stackable>
+              <Grid.Column width={6}>
+                {/* Render extra inputs if the character's 
+                    skill rating is high enough */}
+                {extraInputs("physical")}
+                {extraInputs("mental")}
+                {/* If the consequence level exceeds the 
+                  character type's maxConsequence
+                  then don't render the consequence */}
+                {2 <= maxConsequence
+                  ? <Input label="2" placeholder="Mild"/>
+                  : <></>
+                }
+                {4 <= maxConsequence
+                  ? <Input label="4" placeholder="Moderate"/>
+                  : <></>
+                }
+                {6 <= maxConsequence
+                  ? <Input label="6" placeholder="Severe"/>
+                  : <></>
+                }
+              </Grid.Column>
+            </Grid>
+          </>
+          // If there's no consequences, give some indication why via the comment
+        : <>
+            <h4>
+              CONSEQUENCES
+              <Popup
+                basic
+                header={type}
+                trigger={<Icon className="question circle large"/>} 
+                content={
+                  <>
+                    <p>
+                      {consequenceComment}
+                    </p>
+                  </>
+                }
+              />
+            </h4>
+      </>
+      }
+        
     </>
   )
 }

--- a/src/components/character/sheet/SheetPreview.js
+++ b/src/components/character/sheet/SheetPreview.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Divider, Grid, Segment } from "semantic-ui-react"
+import { Divider, Grid, Label, Segment } from "semantic-ui-react"
 
 import StressConsequences from "./StressConsequences";
 import CharacterAspects from "./CharacterAspects";
@@ -16,7 +16,14 @@ const SheetPreview = props => {
       <Divider horizontal>
         <h4>ID</h4>
       </Divider>
-      <p><strong>Name:</strong> {props.character.name}</p>
+      {/* <div className="flex-space-between"> */}
+        <p><strong>Name:</strong> {props.character.name}</p>
+        <Label
+          tag
+          color="blue"
+          content={props.characterSubType.name}
+        />
+      {/* </div> */}
       <Segment basic placeholder>
         <Grid columns={2} relaxed='very' stackable>
           <Grid.Column>

--- a/src/components/character/sheet/SheetPreview.js
+++ b/src/components/character/sheet/SheetPreview.js
@@ -31,9 +31,7 @@ const SheetPreview = props => {
       <StressConsequences
         physiqueRating={props.physiqueRating}
         willRating={props.willRating}
-        stressMax={props.stressMax}
-        bothStressTypes={props.bothStressTypes}
-        type={props.type}
+        characterSubType={props.characterSubType}
       />
     </>
   )

--- a/src/components/character/sheet/SheetPreview.js
+++ b/src/components/character/sheet/SheetPreview.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Container, Divider, Grid, Segment } from "semantic-ui-react"
+import { Divider, Grid, Segment } from "semantic-ui-react"
 
 import StressConsequences from "./StressConsequences";
 import CharacterAspects from "./CharacterAspects";
@@ -7,36 +7,33 @@ import CharacterSkills from "./CharacterSkills";
 import CharacterStunts from "./CharacterStunts";
 
 const SheetPreview = props => {
-  const character = props.character;
-  const aspects = props.aspects;
-  const skills = props.skills;
-  const stunts = props.stunts;
-  const physiqueRating = props.physiqueRating;
-  const willRating = props.willRating;
-
-  // If it's a preview in the middle of a save:
-  // get the names of all the skills & names/descriptions stunts
+  // This component renders a Character Sheet for:
+  // the character sheet (character detail view)
+  // Review; last stage of creating / editing a character
 
   return (
     <>
       <Divider horizontal>
         <h4>ID</h4>
       </Divider>
-      <p><strong>Name:</strong> {character.name}</p>
+      <p><strong>Name:</strong> {props.character.name}</p>
       <Segment basic placeholder>
         <Grid columns={2} relaxed='very' stackable>
           <Grid.Column>
-            <CharacterAspects aspects={aspects}/>
+            <CharacterAspects aspects={props.aspects}/>
           </Grid.Column>
           <Grid.Column verticalAlign='middle'>
-            <CharacterSkills skills={skills}/>
+            <CharacterSkills skills={props.skills}/>
           </Grid.Column>
         </Grid>
       </Segment>
-      <CharacterStunts stunts={stunts}/>
+      <CharacterStunts stunts={props.stunts}/>
       <StressConsequences
-        physiqueRating={physiqueRating}
-        willRating={willRating}
+        physiqueRating={props.physiqueRating}
+        willRating={props.willRating}
+        stressMax={props.stressMax}
+        bothStressTypes={props.bothStressTypes}
+        type={props.type}
       />
     </>
   )

--- a/src/components/character/sheet/StressBoxes.js
+++ b/src/components/character/sheet/StressBoxes.js
@@ -1,50 +1,79 @@
 import React from "react";
-import { Checkbox, List } from "semantic-ui-react";
+import { Checkbox, Icon, List, Popup } from "semantic-ui-react";
 
 const StressBoxes = props => {
+  const type = props.type;
   const stressType = props.stressType;
+  const bothStressTypes = props.bothStressTypes;
   const rating = props.skillRating;
+  const stressMax = props.stressMax;
 
-  // If stresstype rating is 1-2, they get 1, 2, 3 boxes
-  // If 3-4, they get 1, 2, 3, 4 boxes
-  
-  const checkBox = (number) => {
-    return (
-      <>
-        <strong>{number}</strong><Checkbox/>
-      </>
-    )
+  const makeJSXBoxes = (numberOfBoxes) => {
+    let checkboxes = [];
+    for (let i = 1; i <= numberOfBoxes; i++) {
+      checkboxes.push(
+        <List.Item>
+          <strong>{i}</strong><Checkbox/>
+        </List.Item>
+      )
+    }
+    return checkboxes;
+  }
+
+  const renderBoxes = () => {
+    /* 
+      If relevant skill rating is:
+        0: they get 1, 2 boxes
+        1-2: they get 1, 2, 3, boxes
+        3+: they get 1, 2, 3, 4 boxes
+
+      Also, make sure the amount of stress boxes 
+      doesn't exceed the character type's stressMax value
+    */
+    switch(rating) {
+      default:
+      case 0:
+        return makeJSXBoxes(2 <= stressMax ? 2 : stressMax)
+      case 1:
+      case 2:
+        return makeJSXBoxes(3 <= stressMax ? 3 : stressMax)
+      case 3:
+      case 4:
+      case 5:
+      case 6:
+      case 7:
+      case 8:
+        return makeJSXBoxes(4 <= stressMax ? 4 : stressMax)
+    }
   }
   
-  // TODO: make this DRY-er
-
   return (
     <>
-    <h4> {stressType.toUpperCase()} STRESS </h4>
-     {rating <= 0 
-      ? <List horizontal>
-          <List.Item>{checkBox(1)}</List.Item>
-          <List.Item>{checkBox(2)}</List.Item>
-        </List>
-      : <></>
-     } 
-     {rating === 1 || rating === 2 
-      ? <List horizontal>
-          <List.Item>{checkBox(1)}</List.Item>
-          <List.Item>{checkBox(2)}</List.Item>
-          <List.Item>{checkBox(3)}</List.Item>
-        </List>
-      : <></>
-     }
-     {rating >= 3
-      ? <List horizontal>
-          <List.Item>{checkBox(1)}</List.Item>
-          <List.Item>{checkBox(2)}</List.Item>
-          <List.Item>{checkBox(3)}</List.Item>
-          <List.Item>{checkBox(4)}</List.Item>
-        </List>
-      : <></>
-     }
+      <h4> 
+        {stressType.toUpperCase()} STRESS 
+        {/* A popup explains the logic behind a character's stress tracks */}
+        <Popup
+          basic
+          trigger={<Icon className="info circle large"/>} 
+          content={
+            <>
+              <p>
+                {type} can have up to {stressMax} stress in a single track.
+              </p>
+              <p>
+                {bothStressTypes === true
+                  ? "They have both physical and mental stress tracks"
+                  : "They have only one generic stress track"
+                }
+              </p>
+            </>
+          }
+          className="info circle large"
+          />
+      </h4>
+      <List horizontal>
+        {renderBoxes()}
+      </List>
     </>
   )
 

--- a/src/components/character/sheet/StressBoxes.js
+++ b/src/components/character/sheet/StressBoxes.js
@@ -1,6 +1,13 @@
 import React from "react";
 import { Checkbox, Icon, List, Popup } from "semantic-ui-react";
 
+/*
+  StressBoxes determines the amount of stress checkboxes 
+  to render on a character's sheet based on:
+  - character's skill rating (physique or will)
+  - character type's max stress
+*/
+
 const StressBoxes = props => {
   const type = props.type;
   const stressType = props.stressType;

--- a/src/components/character/sheet/StressBoxes.js
+++ b/src/components/character/sheet/StressBoxes.js
@@ -7,6 +7,7 @@ const StressBoxes = props => {
   const bothStressTypes = props.bothStressTypes;
   const rating = props.skillRating;
   const stressMax = props.stressMax;
+  const stressComment = props.stressComment;
 
   const makeJSXBoxes = (numberOfBoxes) => {
     let checkboxes = [];
@@ -49,31 +50,55 @@ const StressBoxes = props => {
   
   return (
     <>
-      <h4> 
-        {stressType.toUpperCase()} STRESS 
-        {/* A popup explains the logic behind a character's stress tracks */}
-        <Popup
-          basic
-          trigger={<Icon className="info circle large"/>} 
-          content={
-            <>
-              <p>
-                {type} can have up to {stressMax} stress in a single track.
-              </p>
-              <p>
-                {bothStressTypes === true
-                  ? "They have both physical and mental stress tracks"
-                  : "They have only one generic stress track"
+      {/* If the character's type has no stress, don't render any */}
+      {stressMax > 0 
+        ? <>
+            <h4> 
+              {stressType.toUpperCase()} STRESS 
+              {/* A popup explains the logic behind a character's stress tracks */}
+              <Popup
+                basic
+                trigger={<Icon className="info circle large"/>}
+                header={type} 
+                content={
+                  <>
+                    <p>
+                      {stressComment}
+                    </p>
+                    <p>
+                      {bothStressTypes === true
+                        ? "They have both physical and mental stress tracks"
+                        : "They have only one generic stress track"
+                      }
+                    </p>
+                  </>
                 }
-              </p>
-            </>
-          }
-          className="info circle large"
-          />
-      </h4>
-      <List horizontal>
-        {renderBoxes()}
-      </List>
+                />
+            </h4>
+            <List horizontal>
+              {renderBoxes()}
+            </List>
+          </>
+        // If there's no stress, give some indication why via the stress comment 
+        : <>
+            <h4> 
+              {stressType.toUpperCase()} STRESS 
+              <Popup
+                basic
+                header={type}
+                trigger={<Icon className="question circle large"/>} 
+                content={
+                  <>
+                    <p>
+                      {stressComment}
+                    </p>
+                  </>
+                }
+              />
+            </h4>
+          </>
+      }
+
     </>
   )
 

--- a/src/components/character/sheet/StressConsequences.js
+++ b/src/components/character/sheet/StressConsequences.js
@@ -5,21 +5,58 @@ import ConsequenceInputs from "./ConsequenceInputs";
 import "../Character.css";
 
 const StressConsequences = props => {
-  const physiqueRating = props.physiqueRating;
-  const willRating = props.willRating;
+  /* 
+    This component renders:
+    the stress checkboxes
+    consequence inputs
+    for character preview
+  */
+  
+  // STOPPED HERE. SHOULD THERE BE STRESS/CONSEQUENCE COMMENTS?
 
   return (
     <>
       <Grid columns={2} stackable>
         <Grid.Row stretched>
           <Grid.Column width={4}>
-              <StressBoxes stressType="physical" skillRating={physiqueRating}/>
-              <StressBoxes stressType="mental" skillRating={willRating}/>
+            {/* If the character has both stress types, 
+              render both types of stress boxes 
+              otherwise, render one generic set 
+              and pass the highest skill rating */}
+            {props.bothStressTypes 
+              ? <>
+                  <StressBoxes 
+                    stressType="physical" 
+                    skillRating={props.physiqueRating}
+                    stressMax={props.stressMax}
+                    bothStressTypes={props.bothStressTypes}
+                    type={props.type}
+                  />
+                  <StressBoxes 
+                    stressType="mental" 
+                    skillRating={props.willRating}
+                    stressMax={props.stressMax}
+                    bothStressTypes={props.bothStressTypes}
+                    type={props.type}
+                  />
+                </>
+              : <StressBoxes 
+                  stressType="" 
+                  skillRating={props.physiqueRating > props.willRating  
+                    ? props.physiqueRating
+                    : props.willRating
+                  }
+                  stressMax={props.stressMax}
+                  bothStressTypes={props.bothStressTypes}
+                  type={props.type}
+                />
+            }    
           </Grid.Column>
           <Grid.Column width={10}>
             <ConsequenceInputs 
-              willRating={willRating} 
-              physiqueRating={physiqueRating}
+              willRating={props.willRating} 
+              physiqueRating={props.physiqueRating}
+              type={props.type}
             />
           </Grid.Column>
         </Grid.Row>

--- a/src/components/character/sheet/StressConsequences.js
+++ b/src/components/character/sheet/StressConsequences.js
@@ -5,6 +5,14 @@ import ConsequenceInputs from "./ConsequenceInputs";
 import "../Character.css";
 
 const StressConsequences = props => {
+  const characterSubType = props.characterSubType;
+  const type = characterSubType.name;
+  const stressMax = characterSubType.stressMax; 
+  const bothStressTypes = characterSubType.bothStressTypes;
+  const stressComment = characterSubType.stressComment;
+  const maxConsequence = characterSubType.maxConsequence;
+  const consequenceComment = characterSubType.consequenceComment;
+
   /* 
     This component renders:
     the stress checkboxes
@@ -18,26 +26,28 @@ const StressConsequences = props => {
     <>
       <Grid columns={2} stackable>
         <Grid.Row stretched>
-          <Grid.Column width={4}>
+          <Grid.Column width={6}>
             {/* If the character has both stress types, 
               render both types of stress boxes 
               otherwise, render one generic set 
               and pass the highest skill rating */}
-            {props.bothStressTypes 
+            {bothStressTypes 
               ? <>
                   <StressBoxes 
                     stressType="physical" 
                     skillRating={props.physiqueRating}
-                    stressMax={props.stressMax}
-                    bothStressTypes={props.bothStressTypes}
-                    type={props.type}
+                    stressMax={stressMax}
+                    bothStressTypes={bothStressTypes}
+                    type={type}
+                    stressComment={stressComment}
                   />
                   <StressBoxes 
                     stressType="mental" 
                     skillRating={props.willRating}
-                    stressMax={props.stressMax}
-                    bothStressTypes={props.bothStressTypes}
-                    type={props.type}
+                    stressMax={stressMax}
+                    bothStressTypes={bothStressTypes}
+                    type={type}
+                    stressComment={stressComment}
                   />
                 </>
               : <StressBoxes 
@@ -46,9 +56,10 @@ const StressConsequences = props => {
                     ? props.physiqueRating
                     : props.willRating
                   }
-                  stressMax={props.stressMax}
-                  bothStressTypes={props.bothStressTypes}
-                  type={props.type}
+                  stressMax={stressMax}
+                  bothStressTypes={bothStressTypes}
+                  type={type}
+                  stressComment={stressComment}
                 />
             }    
           </Grid.Column>
@@ -56,7 +67,9 @@ const StressConsequences = props => {
             <ConsequenceInputs 
               willRating={props.willRating} 
               physiqueRating={props.physiqueRating}
-              type={props.type}
+              type={type}
+              maxConsequence={maxConsequence}
+              consequenceComment={consequenceComment}
             />
           </Grid.Column>
         </Grid.Row>

--- a/src/components/character/types/SubTypeCard.js
+++ b/src/components/character/types/SubTypeCard.js
@@ -1,0 +1,32 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Button, Card, Icon } from "semantic-ui-react";
+
+const SubTypeCard = props => {
+  const subType = props.subType;
+
+  return (
+    <>
+      <Card
+        raised
+        header={subType.name}
+        description={subType.purpose}
+        meta={`Associated Type: ${subType.characterTypeId}`}
+        // The following safely open a new tab
+        extra={
+          <div className="flex-end">
+            <Link to={`/types/${subType.id}`}>
+              <Button 
+                className="ui button"
+              >
+                <Icon fitted className="file outline"/>
+              </Button>
+            </Link>  
+          </div>
+        }
+      />
+    </>
+  )
+}
+
+export default SubTypeCard;

--- a/src/components/character/types/TypeDetail.js
+++ b/src/components/character/types/TypeDetail.js
@@ -1,0 +1,102 @@
+import React, { useState, useEffect } from "react";
+import { Card, Container } from "semantic-ui-react";
+import ApiManager from "../../../modules/ApiManager";
+
+const TypeDetail = props => {
+  const [subType, setSubType] = useState({});
+  const id = props.subTypeId;
+
+  const getSubType = () => {
+    ApiManager.getSubTypeDetails(id)
+      .then(setSubType)
+  }
+
+  useEffect(()=>{
+    getSubType();
+  }, [])
+
+  return (
+    <>
+      <Container text>
+        <div className="header-container">
+          {/* Having issues with this erroring out before full render */}
+          {subType.characterType 
+            ? <h1> {subType.name}: {subType.characterType.name}</h1>
+            : <></>   
+          }
+        </div>
+        <Card.Group itemsPerRow={1}>
+          <Card
+            header="Competence"
+            description={<p>{subType.competence}</p>}
+          />
+          <Card
+            header="Purpose"
+            description={<p>{subType.purpose}</p>}
+          />
+          <Card
+            header="Aspects"
+            description={
+              <>
+                <p>
+                  {`Max Aspects: ${subType.maxAspects}`}
+                </p>
+                <p>
+                  {subType.aspectComment}
+                </p>
+              </>
+            }
+          />
+          <Card
+            header="Skills"
+            description={
+              <>
+                <p>
+                  {`Max Skill Rating: ${subType.maxSkillRating}`}
+                </p>
+                <p>
+                  {subType.skillRatingComment}
+                </p>
+                <p>
+                  {subType.skillChoiceComment}
+                </p>
+              </>
+            }
+          />
+          <Card
+            header="Stunts"
+            description={
+              <>
+                <p>
+                  {`Max Stunts: ${subType.maxStunts}`}
+                </p>
+                <p>
+                  {subType.stuntComment}
+                </p>
+              </>
+            }
+          />
+          <Card
+            header="Stress"
+            description={
+              <>
+                <p>
+                  {`Maximum Level of Stress Boxes: ${subType.stressMax}`}
+                </p>
+                <p>
+                  Stress Types: 
+                  {subType.bothStressTypes
+                    ? `Physical and Mental`
+                    : `One generic stress type`
+                  }
+                </p>
+              </>
+            }
+          />
+        </Card.Group>     
+      </Container>
+    </>
+  )
+}
+
+export default TypeDetail;

--- a/src/components/character/types/TypeDetail.js
+++ b/src/components/character/types/TypeDetail.js
@@ -5,6 +5,7 @@ import ApiManager from "../../../modules/ApiManager";
 const TypeDetail = props => {
   const [subType, setSubType] = useState({});
   const id = props.subTypeId;
+  const verbose = props.verbose;
 
   const getSubType = () => {
     ApiManager.getSubTypeDetails(id)
@@ -13,7 +14,7 @@ const TypeDetail = props => {
 
   useEffect(()=>{
     getSubType();
-  }, [])
+  }, [id])
 
   return (
     <>
@@ -22,7 +23,7 @@ const TypeDetail = props => {
         <div className="header-container">
           {/* Having issues with this erroring out before full render */}
           {subType.characterType 
-            ? <h1> {subType.name}: {subType.characterType.name}</h1>
+            ? <h2> {subType.name}: {subType.characterType.name}</h2>
             : <></>   
           }
         </div>
@@ -35,65 +36,71 @@ const TypeDetail = props => {
             header="Purpose"
             description={<p>{subType.purpose}</p>}
           />
-          <Card
-            header="Aspects"
-            description={
-              <>
-                <p>
-                  {`Max Aspects: ${subType.maxAspects}`}
-                </p>
-                <p>
-                  {subType.aspectComment}
-                </p>
-              </>
-            }
-          />
-          <Card
-            header="Skills"
-            description={
-              <>
-                <p>
-                  {`Max Skill Rating: ${subType.maxSkillRating}`}
-                </p>
-                <p>
-                  {subType.skillRatingComment}
-                </p>
-                <p>
-                  {subType.skillChoiceComment}
-                </p>
-              </>
-            }
-          />
-          <Card
-            header="Stunts"
-            description={
-              <>
-                <p>
-                  {`Max Stunts: ${subType.maxStunts}`}
-                </p>
-                <p>
-                  {subType.stuntComment}
-                </p>
-              </>
-            }
-          />
-          <Card
-            header="Stress"
-            description={
-              <>
-                <p>
-                  {`Maximum Level of Stress Boxes: ${subType.stressMax}`}
-                </p>
-                <p>
-                  Stress Types: 
-                  {subType.bothStressTypes
-                    ? `Physical and Mental`
-                    : `One generic stress type`
+          {verbose === true 
+            ? <>
+                <Card
+                  header="Aspects"
+                  description={
+                    <>
+                      <p>
+                        {`Max Aspects: ${subType.maxAspects}`}
+                      </p>
+                      <p>
+                        {subType.aspectComment}
+                      </p>
+                    </>
                   }
-                </p>
+                />
+                <Card
+                  header="Skills"
+                  description={
+                    <>
+                      <p>
+                        {`Max Skill Rating: ${subType.maxSkillRating}`}
+                      </p>
+                      <p>
+                        {subType.skillRatingComment}
+                      </p>
+                      <p>
+                        {subType.skillChoiceComment}
+                      </p>
+                    </>
+                  }
+                />
+                <Card
+                  header="Stunts"
+                  description={
+                    <>
+                      <p>
+                        {`Max Stunts: ${subType.maxStunts}`}
+                      </p>
+                      <p>
+                        {subType.stuntComment}
+                      </p>
+                    </>
+                  }
+                />
+                <Card
+                  header="Stress"
+                  description={
+                    <>
+                      <p>
+                        {`Maximum Level of Stress Boxes: ${subType.stressMax}`}
+                      </p>
+                      <p>
+                        Stress Types: 
+                        {subType.bothStressTypes
+                          ? `Physical and Mental`
+                          : `One generic stress type`
+                        }
+                      </p>
+                    </>
+                  }
+                />
               </>
-            }
-          />
+            : <></>
+          }
+          
         </Card.Group>     
       </Container>
     </>

--- a/src/components/character/types/TypeDetail.js
+++ b/src/components/character/types/TypeDetail.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Card, Container } from "semantic-ui-react";
+import { Card, Container, Icon } from "semantic-ui-react";
 import ApiManager from "../../../modules/ApiManager";
 
 const TypeDetail = props => {
@@ -100,7 +100,11 @@ const TypeDetail = props => {
               </>
             : <></>
           }
-          
+          <div className="flex-end">
+            <a target="_blank" rel="noopener noreferrer" href={subType.url}>
+              <Icon fitted link className="linkify"/>
+            </a>
+          </div>
         </Card.Group>     
       </Container>
     </>

--- a/src/components/character/types/TypeDetail.js
+++ b/src/components/character/types/TypeDetail.js
@@ -17,6 +17,7 @@ const TypeDetail = props => {
 
   return (
     <>
+      {/* TODO: URL Link  */}
       <Container text>
         <div className="header-container">
           {/* Having issues with this erroring out before full render */}

--- a/src/components/character/types/TypeList.js
+++ b/src/components/character/types/TypeList.js
@@ -4,6 +4,7 @@ import ApiManager from "../../../modules/ApiManager";
 import SubTypeCard from "./SubTypeCard";
 
 const TypeList = props => {
+  // TODO: a filter / sort by type/subtype bar
   const [typeList, setTypeList] = useState([]);
   const [subTypeList, setSubTypeList] = useState([]);
 

--- a/src/components/character/types/TypeList.js
+++ b/src/components/character/types/TypeList.js
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from "react";
+import { Card, Container } from "semantic-ui-react";
+import ApiManager from "../../../modules/ApiManager";
+import SubTypeCard from "./SubTypeCard";
+
+const TypeList = props => {
+  const [typeList, setTypeList] = useState([]);
+  const [subTypeList, setSubTypeList] = useState([]);
+
+  const getTypeList = () => {
+    return ApiManager.getAll("characterTypes")
+      .then(setTypeList);
+  }
+
+  const getSubTypeList = () => {
+    return ApiManager.getAll("characterSubTypes")
+      .then(setSubTypeList);
+  }
+
+  useEffect(() => {
+    getTypeList();
+    getSubTypeList();
+  }, [])
+
+  return (
+    <>
+      <Container>
+        <div className="header-container">
+          <h1>Character Types</h1>
+        </div>
+        <Card.Group itemsPerRow={3}>
+          {subTypeList.sort((a,b) => a.name.localeCompare(b.name))
+            .map(subType => 
+              <SubTypeCard
+                key={subType.id}
+                subType={subType}
+              />  
+            )
+          
+          }
+        </Card.Group>
+      </Container>
+    </>
+  )
+
+
+}
+
+export default TypeList

--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -24,17 +24,17 @@ const Footer = props => {
           </small>
         </p>
         {/* TODO: Ask permission */}
-        <p>
+        {/* <p>
           <small>
             Fate™ is a trademark of Evil Hat Productions, LLC. The Powered by Fate logo is © Evil Hat Productions, LLC and is used with permission.
           </small>
-        </p>
+        </p> */}
         {/* TODO: Ask permission */}
-        <p>
+        {/* <p>
           <small>
             The Fate Core font is © Evil Hat Productions, LLC and is used with permission. The Four Actions icons were designed by Jeremy Keller.
           </small>
-        </p>
+        </p> */}
       </Container>    
     </div>
   )

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -40,6 +40,7 @@ const NavBar = props => {
         <Menu inverted size="huge" color="blue">
           {/* {MenuItem("home")} */}
           {MenuItem("characters")}
+          {MenuItem("types")}
           {MenuItem("skills")}
           {MenuItem("stunts")}
           {hasUser 

--- a/src/modules/ApiManager.js
+++ b/src/modules/ApiManager.js
@@ -29,6 +29,10 @@ export default {
     return fetch(`${remoteURL}/characters?_embed=characterAspects&_expand=user`)
       .then(results => results.json())
   },
+  getSubTypeDetails(id) {
+    return fetch(`${remoteURL}/characterSubTypes/${id}?_expand=characterType`)
+      .then(results => results.json())
+  },
   getAllExpand(dataType, expandType) {
     return fetch(`${remoteURL}/${dataType}?_expand=${expandType}`)
       .then(results => results.json())

--- a/src/modules/ApiManager.js
+++ b/src/modules/ApiManager.js
@@ -30,7 +30,7 @@ export default {
       .then(results => results.json())
   },
   getCharacterList() {
-    return fetch(`${remoteURL}/characters?_embed=characterAspects&_expand=user`)
+    return fetch(`${remoteURL}/characters?_embed=characterAspects&_expand=user&_expand=characterSubType`)
       .then(results => results.json())
   },
   getSubTypeDetails(id) {

--- a/src/modules/ApiManager.js
+++ b/src/modules/ApiManager.js
@@ -5,6 +5,10 @@ export default {
     return fetch(`${remoteURL}/${dataType}/${id}`)
       .then(result => result.json());
   },
+  getCharacterWithType(id) {
+    return fetch(`${remoteURL}/characters/${id}?_expand=characterSubType`)
+      .then(result => result.json());
+  },
   getAll(dataType) {
     return fetch(`${remoteURL}/${dataType}`)
       .then(result => result.json());


### PR DESCRIPTION
Character types and subtype functionality added:

- [x] Given a user wants to see each different character type, they can see a list/card view of the types, with affordances to view more details about each type. 

(Users cannot create, edit, or delete character types)

Confirm the following are true:

Character ID
- [x] Given a user wants to create a new or edit an existing character, they are presented with 1+ selectors to choose the character's type (and subtype) on the first step of the form (character ID).
- [x] Choosing one of these subtypes will display competence, purpose, and a url (to the character type on the srd)

The decision of character type (and subtypes) modifies the next steps on the form as follows:

Aspects:
- [x] the number of aspect inputs presented on the aspect form
- [x] a comment on aspects for that particular character type/subtype

Skills:
- [x] the number and rank of skill multiselectors on the skill form
- [x] a comment on skill ratings for that particular character type/subtype
- [x] a comment on skill choices for that particular character type/subtype

Stunts
- [x] the number of stunt selectors on the stunt form (and perhaps removes the stunt menu/step entirely)
- [x] a comment on stunts for that particular character type/subtype

Stress
- [x]  limiting the maximum amount of stress a character can have based on their type
- [x] displaying one stress type or both, depending on the character type
- [x] displaying hot tip if there are no stress boxes

Consequences
- [x] limiting the max amount of consequences based on type
- [x] displaying hot tip if there are no consequences

Saving
- [x] ensure that new characters created in this way also have their subtype saved

Editing
- [x] ensure that edited characters created in this way also have their subtype saved

Character Type Tag Displayed on:
- [x] both character list / card
- [x] character sheet preview (detail view and the last page of an edit / create)